### PR TITLE
shrink images by cleaning up conda and apt after installing

### DIFF
--- a/configs/intelpython2_core/Dockerfile
+++ b/configs/intelpython2_core/Dockerfile
@@ -32,5 +32,7 @@ ENV ACCEPT_INTEL_PYTHON_EULA=yes
 
 RUN conda config --add channels intel\
     && conda install  -y -q intelpython2_core=2018.0.1 python=2 \
+    && conda clean --all && \
     && apt-get update -qqq \
-    && apt-get install -y -q g++
+    && apt-get install -y -q g++ \
+    && apt-get autoremove

--- a/configs/intelpython2_core/Dockerfile
+++ b/configs/intelpython2_core/Dockerfile
@@ -32,7 +32,7 @@ ENV ACCEPT_INTEL_PYTHON_EULA=yes
 
 RUN conda config --add channels intel\
     && conda install  -y -q intelpython2_core=2018.0.1 python=2 \
-    && conda clean --all && \
+    && conda clean --all \
     && apt-get update -qqq \
     && apt-get install -y -q g++ \
     && apt-get autoremove

--- a/configs/intelpython2_full/Dockerfile
+++ b/configs/intelpython2_full/Dockerfile
@@ -32,7 +32,7 @@ ENV ACCEPT_INTEL_PYTHON_EULA=yes
 
 RUN conda config --add channels intel\
     && conda install  -y -q intelpython2_full=2018.0.1 python=2 \
-    && conda clean --all && \
+    && conda clean --all \
     && apt-get update -qqq \
     && apt-get install -y -q g++ \
     && apt-get autoremove

--- a/configs/intelpython2_full/Dockerfile
+++ b/configs/intelpython2_full/Dockerfile
@@ -32,5 +32,7 @@ ENV ACCEPT_INTEL_PYTHON_EULA=yes
 
 RUN conda config --add channels intel\
     && conda install  -y -q intelpython2_full=2018.0.1 python=2 \
+    && conda clean --all && \
     && apt-get update -qqq \
-    && apt-get install -y -q g++
+    && apt-get install -y -q g++ \
+    && apt-get autoremove

--- a/configs/intelpython3_core/Dockerfile
+++ b/configs/intelpython3_core/Dockerfile
@@ -32,5 +32,7 @@ ENV ACCEPT_INTEL_PYTHON_EULA=yes
 
 RUN conda config --add channels intel\
     && conda install  -y -q intelpython3_core=2018.0.1 python=3 \
+    && conda clean --all && \
     && apt-get update -qqq \
-    && apt-get install -y -q g++
+    && apt-get install -y -q g++ \
+    && apt-get autoremove

--- a/configs/intelpython3_core/Dockerfile
+++ b/configs/intelpython3_core/Dockerfile
@@ -32,7 +32,7 @@ ENV ACCEPT_INTEL_PYTHON_EULA=yes
 
 RUN conda config --add channels intel\
     && conda install  -y -q intelpython3_core=2018.0.1 python=3 \
-    && conda clean --all && \
+    && conda clean --all \
     && apt-get update -qqq \
     && apt-get install -y -q g++ \
     && apt-get autoremove

--- a/configs/intelpython3_full/Dockerfile
+++ b/configs/intelpython3_full/Dockerfile
@@ -32,7 +32,7 @@ ENV ACCEPT_INTEL_PYTHON_EULA=yes
 
 RUN conda config --add channels intel\
     && conda install  -y -q intelpython3_full=2018.0.1 python=3 \
-    && conda clean --all && \
+    && conda clean --all \
     && apt-get update -qqq \
     && apt-get install -y -q g++ \
     && apt-get autoremove

--- a/configs/intelpython3_full/Dockerfile
+++ b/configs/intelpython3_full/Dockerfile
@@ -32,5 +32,7 @@ ENV ACCEPT_INTEL_PYTHON_EULA=yes
 
 RUN conda config --add channels intel\
     && conda install  -y -q intelpython3_full=2018.0.1 python=3 \
+    && conda clean --all && \
     && apt-get update -qqq \
-    && apt-get install -y -q g++
+    && apt-get install -y -q g++ \
+    && apt-get autoremove

--- a/tpls/tpl.Dockerfile
+++ b/tpls/tpl.Dockerfile
@@ -32,5 +32,8 @@ ENV ACCEPT_INTEL_PYTHON_EULA=yes
 
 RUN conda config --add channels intel\
     && conda install {{install_args}} -y -q intelpython{{pyver}}_{{package}}={{update_number}}{{build_number}} python={{pyver}} \
+    && conda clean --all && \
     && apt-get update -qqq \
-    && apt-get install -y -q g++
+    && apt-get install -y -q g++ \
+    && apt-get autoremove
+

--- a/tpls/tpl.Dockerfile
+++ b/tpls/tpl.Dockerfile
@@ -32,7 +32,7 @@ ENV ACCEPT_INTEL_PYTHON_EULA=yes
 
 RUN conda config --add channels intel\
     && conda install {{install_args}} -y -q intelpython{{pyver}}_{{package}}={{update_number}}{{build_number}} python={{pyver}} \
-    && conda clean --all && \
+    && conda clean --all \
     && apt-get update -qqq \
     && apt-get install -y -q g++ \
     && apt-get autoremove


### PR DESCRIPTION
cleans up temporary conda and apt resources after installation has been finished in order to keep the image small