### PR TITLE
Feature/provide default cmd as the original python image is doing it

### DIFF
--- a/configs/intelpython2_core/Dockerfile
+++ b/configs/intelpython2_core/Dockerfile
@@ -34,7 +34,6 @@ RUN conda config --add channels intel\
     && conda install  -y -q intelpython2_core=2018.0.1 python=2 \
     && conda clean --all \
     && apt-get update -qqq \
-    && apt-get install -y -q g++
     && apt-get install -y -q g++ \
     && apt-get autoremove
 

--- a/configs/intelpython2_core/Dockerfile
+++ b/configs/intelpython2_core/Dockerfile
@@ -34,3 +34,5 @@ RUN conda config --add channels intel\
     && conda install  -y -q intelpython2_core=2018.0.1 python=2 \
     && apt-get update -qqq \
     && apt-get install -y -q g++
+
+CMD ["python"]

--- a/configs/intelpython2_core/README.md
+++ b/configs/intelpython2_core/README.md
@@ -1,6 +1,6 @@
 Docker images for [Intel Distribution for Python](https://software.intel.com/en-us/intel-distribution-for-python)
 
-The image defaults to starting with a bash shell. Intel Python is on the path. There is 1 image for every install configuration.
+The image defaults to starting with a python interpreter. There is 1 image for every install configuration.
 
 Images:
 

--- a/configs/intelpython2_full/Dockerfile
+++ b/configs/intelpython2_full/Dockerfile
@@ -34,3 +34,5 @@ RUN conda config --add channels intel\
     && conda install  -y -q intelpython2_full=2018.0.1 python=2 \
     && apt-get update -qqq \
     && apt-get install -y -q g++
+
+CMD ["python"]

--- a/configs/intelpython2_full/README.md
+++ b/configs/intelpython2_full/README.md
@@ -1,6 +1,6 @@
 Docker images for [Intel Distribution for Python](https://software.intel.com/en-us/intel-distribution-for-python)
 
-The image defaults to starting with a bash shell. Intel Python is on the path. There is 1 image for every install configuration.
+The image defaults to starting with a python interpreter. There is 1 image for every install configuration.
 
 Images:
 

--- a/configs/intelpython3_core/Dockerfile
+++ b/configs/intelpython3_core/Dockerfile
@@ -34,3 +34,5 @@ RUN conda config --add channels intel\
     && conda install  -y -q intelpython3_core=2018.0.1 python=3 \
     && apt-get update -qqq \
     && apt-get install -y -q g++
+
+CMD ["python"]

--- a/configs/intelpython3_core/README.md
+++ b/configs/intelpython3_core/README.md
@@ -1,6 +1,6 @@
 Docker images for [Intel Distribution for Python](https://software.intel.com/en-us/intel-distribution-for-python)
 
-The image defaults to starting with a bash shell. Intel Python is on the path. There is 1 image for every install configuration.
+The image defaults to starting with a python interpreter. There is 1 image for every install configuration.
 
 Images:
 

--- a/configs/intelpython3_full/Dockerfile
+++ b/configs/intelpython3_full/Dockerfile
@@ -34,3 +34,5 @@ RUN conda config --add channels intel\
     && conda install  -y -q intelpython3_full=2018.0.1 python=3 \
     && apt-get update -qqq \
     && apt-get install -y -q g++
+
+CMD ["python"]

--- a/configs/intelpython3_full/README.md
+++ b/configs/intelpython3_full/README.md
@@ -1,6 +1,6 @@
 Docker images for [Intel Distribution for Python](https://software.intel.com/en-us/intel-distribution-for-python)
 
-The image defaults to starting with a bash shell. Intel Python is on the path. There is 1 image for every install configuration.
+The image defaults to starting with a python interpreter. There is 1 image for every install configuration.
 
 Images:
 

--- a/tpls/tpl.Dockerfile
+++ b/tpls/tpl.Dockerfile
@@ -34,3 +34,6 @@ RUN conda config --add channels intel\
     && conda install {{install_args}} -y -q intelpython{{pyver}}_{{package}}={{update_number}}{{build_number}} python={{pyver}} \
     && apt-get update -qqq \
     && apt-get install -y -q g++
+
+CMD ["python"]
+

--- a/tpls/tpl.README.md
+++ b/tpls/tpl.README.md
@@ -1,6 +1,6 @@
 Docker images for [Intel Distribution for Python](https://software.intel.com/en-us/intel-distribution-for-python)
 
-The image defaults to starting with a bash shell. Intel Python is on the path. There is 1 image for every install configuration.
+The image defaults to starting with a python interpreter. There is 1 image for every install configuration.
 
 Images:
 


### PR DESCRIPTION
in order to keep the difference between the intel image and the original python image as small as possible, provide the same default command to the docker image.